### PR TITLE
Fix optimisic quantity change in cart page

### DIFF
--- a/apps/qopnet-commerce/pages/cart/index.tsx
+++ b/apps/qopnet-commerce/pages/cart/index.tsx
@@ -194,9 +194,18 @@ export const BusinessOrderItem = ({ item }) => {
   const {
     register,
     handleSubmit,
+    setValue,
     watch,
     formState: { errors },
   } = useForm()
+
+  const { data } = useSWR('/api/business/orders/my/cart')
+
+  const quantity = data.businessOrder.businessOrderItems?.filter(
+    (_item) => _item.id === item.id
+  )[0].quantity
+
+  setValue('customQuantity', quantity)
 
   const onSubmitCustomQuantity = (data) => {
     handleCustomQuantityBusinessOrderItem(
@@ -254,6 +263,7 @@ export const BusinessOrderItem = ({ item }) => {
               ...data.businessOrder,
               businessOrderItems: [...filtered],
             },
+            quantity: item.quantity + 1,
           }
         },
         false
@@ -289,6 +299,7 @@ export const BusinessOrderItem = ({ item }) => {
               ...data.businessOrder,
               businessOrderItems: [...filtered],
             },
+            quantity: item.quantity - 1,
           }
         },
         false
@@ -326,6 +337,7 @@ export const BusinessOrderItem = ({ item }) => {
               ...data.businessOrder,
               businessOrderItems: [...filtered],
             },
+            quantity: customQuantity,
           }
         },
         false


### PR DESCRIPTION
The code before was already optimistic, the only problem was it didn't trigger a rerender after the local cache was updated. 

I read https://github.com/vercel/swr/issues/313 it has something to do with the way they implemented the reference check of the return value inside mutate(). So the workaround is to add another field in the return value.

Now it works.